### PR TITLE
fix: removing one of the octane supervisors

### DIFF
--- a/deployment/octane/RoadRunner/supervisord.roadrunner.conf
+++ b/deployment/octane/RoadRunner/supervisord.roadrunner.conf
@@ -11,19 +11,6 @@ stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
-[program:octane-2]
-process_name=second_octane
-command=php %(ENV_ROOT)s/artisan octane:start --server=roadrunner --host=0.0.0.0 --port=8000 --rpc-port=6001 --rr-config=%(ENV_ROOT)s/.rr.yaml
-memory=128MB
-user=%(ENV_USER)s
-autostart=true
-autorestart=true
-environment=LARAVEL_OCTANE="1"
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-
 [program:laravel-worker]
 process_name=laravel-worker
 command=php %(ENV_ROOT)s/artisan horizon

--- a/deployment/octane/RoadRunner/supervisord.roadrunner.conf
+++ b/deployment/octane/RoadRunner/supervisord.roadrunner.conf
@@ -35,7 +35,7 @@ redirect_stderr=true
 stdout_logfile=%(ENV_ROOT)s/storage/logs/worker.log
 
 [program:laravel-worker-2]
-process_name=laravel-worker
+process_name=laravel-worker-2
 command=php %(ENV_ROOT)s/artisan horizon
 autostart=true
 autorestart=true


### PR DESCRIPTION
- added migration service variables
- added access logs
- road runner config update
- updated road runner to version 3
- added open telemetry
- added open telemetry
- telemetry update
- added production debug logs
- container update
- container update
- updated stunnel redis config
- altered road runner configs
- added sms and fcm configs
- added zoho credentials to docker webserver
- loadenv update
- run docs generator command on deployment
- added INTEGRATION_ENCRYPTION_KEY env credential mapping
- optimization: increased the number of supervisor workers and updated the road runner pool
- using laravel horizon for job workers
- renaming second laravel worker to worker 2
- renaming second laravel worker to worker 2
