### PR TITLE
fix: octane server

### DIFF
--- a/deployment/octane/RoadRunner/.rr.prod.yaml
+++ b/deployment/octane/RoadRunner/.rr.prod.yaml
@@ -13,13 +13,13 @@ http:
   uploads:
     forbid: [".php", ".exe", ".bat", ".sh"]
   pool:
-    allocate_timeout: 1800s
-    destroy_timeout: 1800s
+    allocate_timeout: 1h
+    destroy_timeout: 1h
     num_workers: 0
     max_queue_size: 0
     supervisor:
       max_worker_memory: 0
-      exec_ttl: 1800s
+      exec_ttl: 1h
 metrics:
   address: "0.0.0.0:2112"
 logs:


### PR DESCRIPTION
- added migration service variables
- added access logs
- road runner config update
- updated road runner to version 3
- added open telemetry
- added open telemetry
- telemetry update
- added production debug logs
- container update
- container update
- updated stunnel redis config
- altered road runner configs
- added sms and fcm configs
- added zoho credentials to docker webserver
- loadenv update
- run docs generator command on deployment
- added INTEGRATION_ENCRYPTION_KEY env credential mapping
- optimization: increased the number of supervisor workers and updated the road runner pool
- using laravel horizon for job workers
- renaming second laravel worker to worker 2
- renaming second laravel worker to worker 2
- road runner update
- supervisor update
- raise the timeout to 30 minutes
- road runner timeout update
