### PR TITLE
fix: running laravel octane as a php process instead of using supervisor

### DIFF
--- a/deployment/start-container
+++ b/deployment/start-container
@@ -53,18 +53,8 @@ elif [ ${container_mode} = "http" ]; then
     elif [ ${octane_server}  = "swoole" ]; then
         exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.swoole.conf
     elif [ ${octane_server}  = "roadrunner" ]; then
-        exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.roadrunner.conf
+        php artisan octane:start --server=roadrunner --host=0.0.0.0 --port=8000 --rpc-port=6001 --rr-config=.rr.yaml
     else
         echo "Invalid Octane server supplied."
         exit 1
     fi
-elif [ ${container_mode} = "scheduler" ]; then
-    initialStuff
-    exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.scheduler.conf
-elif [ ${container_mode} = "worker" ]; then
-    initialStuff
-    exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.worker.conf
-else
-    echo "Container mode mismatched."
-    exit 1
-fi


### PR DESCRIPTION
- running laravel octane as a php process instead of using supervisor
