### PR TITLE
fix: running laravel octane as a php process instead of using supervisor

### DIFF
--- a/deployment/start-container
+++ b/deployment/start-container
@@ -58,3 +58,8 @@ elif [ ${container_mode} = "http" ]; then
         echo "Invalid Octane server supplied."
         exit 1
     fi
+else
+    echo "Invalid container mode supplied."
+    exit 1
+fi
+


### PR DESCRIPTION
- added migration service variables
- added access logs
- road runner config update
- updated road runner to version 3
- added open telemetry
- added open telemetry
- telemetry update
- added production debug logs
- container update
- container update
- updated stunnel redis config
- altered road runner configs
- added sms and fcm configs
- added zoho credentials to docker webserver
- loadenv update
- run docs generator command on deployment
- added INTEGRATION_ENCRYPTION_KEY env credential mapping
- optimization: increased the number of supervisor workers and updated the road runner pool
- using laravel horizon for job workers
- renaming second laravel worker to worker 2
- renaming second laravel worker to worker 2
- road runner update
- supervisor update
- raise the timeout to 30 minutes
- road runner timeout update
- admin pods update
- added jwt secret
- sed fix
- load env update
- running laravel octane as a php process instead of using supervisor
- running laravel octane as a php process instead of using supervisor
