### PR TITLE
fix: octane server

### DIFF
--- a/deployment/octane/RoadRunner/supervisord.roadrunner.conf
+++ b/deployment/octane/RoadRunner/supervisord.roadrunner.conf
@@ -1,16 +1,3 @@
-[program:octane]
-process_name=%(program_name)s_%(process_num)02d
-command=php %(ENV_ROOT)s/artisan octane:start --server=roadrunner --host=0.0.0.0 --port=8000 --rpc-port=6001 --rr-config=%(ENV_ROOT)s/.rr.yaml
-memory=128MB
-user=%(ENV_USER)s
-autostart=true
-autorestart=true
-environment=LARAVEL_OCTANE="1"
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-
 [program:laravel-worker]
 process_name=laravel-worker
 command=php %(ENV_ROOT)s/artisan horizon

--- a/deployment/start-container
+++ b/deployment/start-container
@@ -53,6 +53,7 @@ elif [ ${container_mode} = "http" ]; then
     elif [ ${octane_server}  = "swoole" ]; then
         exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.swoole.conf
     elif [ ${octane_server}  = "roadrunner" ]; then
+        exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.roadrunner.conf
         php artisan octane:start --server=roadrunner --host=0.0.0.0 --port=8000 --rpc-port=6001 --rr-config=.rr.yaml
     else
         echo "Invalid Octane server supplied."


### PR DESCRIPTION
- added migration service variables
- added access logs
- road runner config update
- updated road runner to version 3
- added open telemetry
- added open telemetry
- telemetry update
- added production debug logs
- container update
- container update
- updated stunnel redis config
- altered road runner configs
- added sms and fcm configs
- added zoho credentials to docker webserver
- loadenv update
- run docs generator command on deployment
- added INTEGRATION_ENCRYPTION_KEY env credential mapping
- optimization: increased the number of supervisor workers and updated the road runner pool
- using laravel horizon for job workers
- renaming second laravel worker to worker 2
- renaming second laravel worker to worker 2
- road runner update
- supervisor update
- raise the timeout to 30 minutes
- road runner timeout update
- admin pods update
- added jwt secret
- sed fix
- load env update
- running laravel octane as a php process instead of using supervisor
- running laravel octane as a php process instead of using supervisor
- use supervisor to run queue workers only
