### PR TITLE
fix: octane server

### DIFF
--- a/RoadRunner.Alpine.Dockerfile
+++ b/RoadRunner.Alpine.Dockerfile
@@ -123,13 +123,12 @@ COPY --link --chown=${USER}:${USER} deployment/supervisord.*.conf /etc/superviso
 COPY --link --chown=${USER}:${USER} deployment/php.ini ${PHP_INI_DIR}/conf.d/99-octane.ini
 COPY --link --chown=${USER}:${USER} deployment/octane/RoadRunner/.rr.prod.yaml ./.rr.yaml
 COPY --link --chown=${USER}:${USER} deployment/start-container /usr/local/bin/start-container
-COPY --link --chown=${USER}:${USER} deployment/start-supervisor /usr/local/bin/start-supervisor
 COPY --link --chown=${USER}:${USER} deployment/loadenv /usr/local/bin/loadenv
 
 # copy redis-client.conf to working directory
 COPY --link --chown=${USER}:${USER} deployment/redis-client.conf ${ROOT}/redis-client.conf
 
-RUN chmod +x /usr/local/bin/start-container /usr/local/bin/loadenv /usr/local/bin/start-supervisor
+RUN chmod +x /usr/local/bin/start-container /usr/local/bin/loadenv
 
 RUN cat deployment/utilities.sh >> ~/.bashrc
 


### PR DESCRIPTION
- added migration service variables
- added access logs
- road runner config update
- updated road runner to version 3
- added open telemetry
- added open telemetry
- telemetry update
- added production debug logs
- container update
- container update
- updated stunnel redis config
- altered road runner configs
- added sms and fcm configs
- added zoho credentials to docker webserver
- loadenv update
- run docs generator command on deployment
- added INTEGRATION_ENCRYPTION_KEY env credential mapping
- optimization: increased the number of supervisor workers and updated the road runner pool
- using laravel horizon for job workers
- renaming second laravel worker to worker 2
- renaming second laravel worker to worker 2
- road runner update
- supervisor update
- raise the timeout to 30 minutes
- road runner timeout update
- admin pods update
- added jwt secret
- sed fix
- load env update
- running laravel octane as a php process instead of using supervisor
- running laravel octane as a php process instead of using supervisor
- use supervisor to run queue workers only
- use supervisor to run queue workers only
- fix: use supervisor to run queue workers only
- fix: use supervisor to run queue workers only
- fix: run supervisor using horizon
- fix: run supervisor using horizon
- fix: run supervisor using horizon
- fix: run supervisor using horizon
- fix: run supervisor using horizon
- fix: run supervisor using horizon
- fix: run supervisor using horizon
- road runner update
- fix: road runner update
- adding supervisor as a separate process
- adding supervisor as a separate process
- adding horizon as a separate process
- adding horizon as a separate process
- adding horizon as a separate process
- adding horizon as a separate process
- adding horizon as a separate process
- adding horizon as a separate process
- adding horizon as a separate process
