### PR TITLE
fix: octane server

### DIFF
--- a/deployment/octane/RoadRunner/.rr.prod.yaml
+++ b/deployment/octane/RoadRunner/.rr.prod.yaml
@@ -2,6 +2,7 @@ version: '3'
 rpc:
   listen: 'tcp://127.0.0.1:6001'
 server:
+  command: "php artisan horizon"
   relay: pipes
 http:
   middleware: [ "static", "gzip", "headers", "http_metrics" ]
@@ -31,21 +32,5 @@ logs:
         log_output: "/var/log/containers/http.log"
         max_age: 24
         compress: true
-
-# run php artisan horizon as a separate worker
-workers:
-  default:
-    command: "php artisan horizon"
-    relay: pipes
-    pool:
-      num_workers: 1
-      max_jobs: 100
-      max_memory: 128M
-      allocate_timeout: 1h
-      destroy_timeout: 1h
-      supervisor:
-        max_worker_memory: 0
-        exec_ttl: 1h
-
 status:
     address: localhost:2114


### PR DESCRIPTION
- added migration service variables
- added access logs
- road runner config update
- updated road runner to version 3
- added open telemetry
- added open telemetry
- telemetry update
- added production debug logs
- container update
- container update
- updated stunnel redis config
- altered road runner configs
- added sms and fcm configs
- added zoho credentials to docker webserver
- loadenv update
- run docs generator command on deployment
- added INTEGRATION_ENCRYPTION_KEY env credential mapping
- optimization: increased the number of supervisor workers and updated the road runner pool
- using laravel horizon for job workers
- renaming second laravel worker to worker 2
- renaming second laravel worker to worker 2
- road runner update
- supervisor update
- raise the timeout to 30 minutes
- road runner timeout update
- admin pods update
- added jwt secret
- sed fix
- load env update
- running laravel octane as a php process instead of using supervisor
- running laravel octane as a php process instead of using supervisor
- use supervisor to run queue workers only
- use supervisor to run queue workers only
- fix: use supervisor to run queue workers only
- fix: use supervisor to run queue workers only
- fix: run supervisor using horizon
- fix: run supervisor using horizon
- fix: run supervisor using horizon
- fix: run supervisor using horizon
- fix: run supervisor using horizon
- fix: run supervisor using horizon
- fix: run supervisor using horizon
- road runner update
- fix: road runner update
- adding supervisor as a separate process
- adding supervisor as a separate process
- adding horizon as a separate process
- adding horizon as a separate process
- adding horizon as a separate process
- adding horizon as a separate process
- adding horizon as a separate process
- adding horizon as a separate process
- adding horizon as a separate process
- adding horizon as a separate process
