### PR TITLE
octane server

### DIFF
--- a/deployment/octane/RoadRunner/.rr.prod.yaml
+++ b/deployment/octane/RoadRunner/.rr.prod.yaml
@@ -25,6 +25,11 @@ metrics:
 logs:
   mode: production
   level: debug
-  output: [stdout]
+  channels:
+    http:
+      file_logger_options:
+        log_output: "/var/www/html/storage/logs/http.log"
+        max_age: 24
+        compress: true
 status:
     address: localhost:2114

--- a/deployment/octane/RoadRunner/supervisord.roadrunner.conf
+++ b/deployment/octane/RoadRunner/supervisord.roadrunner.conf
@@ -6,7 +6,7 @@ autorestart=true
 user=%(ENV_USER)s
 numprocs=1
 redirect_stderr=true
-stdout_logfile=/dev/stdout
+stdout_logfile=%(ENV_ROOT)s/storage/logs/octane-worker.log
 
 [program:laravel-horizon-worker]
 process_name=laravel-horizon-worker
@@ -16,7 +16,7 @@ autorestart=true
 user=%(ENV_USER)s
 numprocs=1
 redirect_stderr=true
-stdout_logfile=/dev/stdout
+stdout_logfile=%(ENV_ROOT)s/storage/logs/horizon-worker.log
 
 [program:laravel-schedule-worker]
 process_name=laravel-schedule-worker
@@ -26,7 +26,7 @@ autorestart=true
 user=%(ENV_USER)s
 numprocs=1
 redirect_stderr=true
-stdout_logfile=/dev/stdout
+stdout_logfile=%(ENV_ROOT)s/storage/logs/schedule-worker.log
 
 [include]
 files=/etc/supervisor/supervisord.conf


### PR DESCRIPTION
- added imagick item
- view logs on console
- load env update
- added tenants schedule
- added rount optimization link
- added rount optimization link
- reducing worker memory
- road runner update
- updated road runner configuration
- php ini update
- added algolia keys
- added scamble custom export
- fix: added horizon to start container - jobs not running
- fix: added horizon to start container - jobs not running
- fix: added horizon to start container - jobs not running
- fix: switching to supervisor and updating resources to a minimum
- fix: road runner supervisor naming update
- fix: reducing php memory consumption
- fix: added pdf policy on imagemagick
- fix: docker update imagemagick
- fix: image magick update
- fix: docker update
- fix: road runner imagick update
- fix: road runner imagick update
- fix: imagemaick
- fix: removed custom docs exporter command from start container
- fix: added gcp credentials
- fix: added gcp credentials
- fix: enabled road runner logs
- fix: updated log location
- fix: allow permissions on logs folder
- fix: load env updates
- fix: added real path cache size
- test: using stdout to check if it will log on gke
- test: using stdout to check if it will log on gke
