### PR TITLE
octane server

### DIFF
--- a/deployment/octane/RoadRunner/.rr.prod.yaml
+++ b/deployment/octane/RoadRunner/.rr.prod.yaml
@@ -24,12 +24,10 @@ metrics:
   address: "0.0.0.0:2112"
 logs:
   mode: production
-  level: debug
-  channels:
-    http:
-      file_logger_options:
-        log_output: "/var/www/html/storage/logs/http.log"
-        max_age: 24
-        compress: true
+  level: error
+  encoding: json
+  output:
+    - stdout
+    - http.log
 status:
     address: localhost:2114


### PR DESCRIPTION
- added imagick item
- view logs on console
- load env update
- added tenants schedule
- added rount optimization link
- added rount optimization link
- reducing worker memory
- road runner update
- updated road runner configuration
- php ini update
- added algolia keys
- added scamble custom export
- fix: added horizon to start container - jobs not running
- fix: added horizon to start container - jobs not running
- fix: added horizon to start container - jobs not running
- fix: switching to supervisor and updating resources to a minimum
- fix: road runner supervisor naming update
- fix: reducing php memory consumption
- fix: added pdf policy on imagemagick
- fix: docker update imagemagick
- fix: image magick update
- fix: docker update
- fix: road runner imagick update
- fix: road runner imagick update
- fix: imagemaick
- fix: removed custom docs exporter command from start container
- fix: added gcp credentials
- fix: added gcp credentials
- fix: enabled road runner logs
- fix: updated log location
- fix: allow permissions on logs folder
- fix: load env updates
- fix: added real path cache size
- test: using stdout to check if it will log on gke
- test: using stdout to check if it will log on gke
- fix: added redis client
- chore: added metabase configuration variables
- chore: added hmac variables
- fix: updated load env added - distance matrix update
- fix: log http logs to stdout
